### PR TITLE
Fixes

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -151,7 +151,10 @@ pub fn parse_instruction(input: &[u8]) -> IResult<&[u8], Opcode, VerboseError<&[
             let (i, bytes) = take(1usize)(i)?;
             (i, Opcode::Jr(Some(Flag::NZ), bytes[0]))
         },
-        0x30 => (i, Opcode::Stop),
+        0x30 => {
+            let (i, bytes) = take(1usize)(i)?;
+            (i, Opcode::Jr(Some(Flag::NC), bytes[0]))
+        },
         0x01 => {
             let (i, short) = le_u16(i)?;
             (i, Opcode::StoreImm16(Register16::BC, short))


### PR DESCRIPTION
- 0x30 should be a Jr NC instruction according to https://www.pastraiser.com/cpu/gameboy/gameboy_opcodes.html

- StoreImm16Sp(u16) is covered by StoreImm16(Register16::SP, u16) variant already